### PR TITLE
Ability to run Superpeer as a service

### DIFF
--- a/src/main/java/SuperPeer.java
+++ b/src/main/java/SuperPeer.java
@@ -1,4 +1,3 @@
-
 import ether.TransactionsManager;
 
 import io.left.rightmesh.mesh.JavaMeshManager;
@@ -7,23 +6,28 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 public class SuperPeer {
-
     //TODO: Add logger instead of system.out
     public static final String TAG = SuperPeer.class.getCanonicalName();
 
     private static final String EXIT_CMD = "exit";
     private static final String CLOSE_CHANNEL_CMD = "close";
 
-
     JavaMeshManager mm;
     private boolean isRunning = true;
     private TransactionsManager tm;
 
     public static void main(String[] args) {
-        SuperPeer p = new SuperPeer();
+        if (args.length > 0 && (args[0].equals("-h") || args[0].equals("--headless"))) {
+            // Doesn't read from STDIN if run with `-h` or `--headless`.
+            // Useful for backgrounding.
+            SuperPeer serviceMode = new SuperPeer(false);
+        } else {
+            // Default condition, runs in interactive mode.
+            SuperPeer interactiveMode = new SuperPeer(true);
+        }
     }
 
-    public SuperPeer() {
+    public SuperPeer(boolean interactive) {
         mm = new JavaMeshManager(true);
         System.out.println("Superpeer MeshID: " + mm.getUuid());
         System.out.println("Superpeer is waiting for library ... ");

--- a/superpeer.service
+++ b/superpeer.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=RightMesh Superpeer
+[Service]
+ExecStart=/home/ubuntu/Superpeer/build/install/Superpeer/bin/Superpeer --headless
+User=ubuntu


### PR DESCRIPTION
This PR adds two functionalities.

The first is a "headless" mode, accessible by running the binary with `-h` or `--headless`. This mode doesn't read from stdin, and instead infinite loops until killed. A shutdown hook handles shutting down the library when the service is killed.

The second is to create a Systemctl service unit to run the Superpeer on Ubuntu. Simply run `sudo cp superpeer.service /etc/systemd/system/ && sudo systemctl enable superpeer` to install the service, then `sudo systemctl start superpeer` to run it. `journalctl -u superpeer.service -ef`will allow you to tail the logs. `sudo systemctl [stop|restart] superpeer` both shut down the service cleanly.

This branch forks off of `quickfix2` in order to function correctly, the only new changes are the last three commits: https://github.com/RightMesh/Superpeer/commit/690afd9de03832281eb0136a7888bd7030c0a3ff, https://github.com/RightMesh/Superpeer/commit/1146acd91b2c9458a3c3c03ab4a3863335a898f2, and https://github.com/RightMesh/Superpeer/commit/aebc66af013e6458b86666474c654278c78311e5.

An instance of this code is running at `34.211.226.248`.