### PR TITLE
Document Service Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ If run without arguments Superpeer polls STDIN for input - typing `exit` will sh
 
 By default RightMesh devices with internet connections will connect to a Superpeer operated by RightMesh at `research.rightmesh.io`. In the future the goal is to have a network of Superpeers, with Superpeers implemented and operated by both RightMesh and community members.
 
-If you would like to have devices use your Superpeer instance for testing, you can hard-code its address into a RightMesh application to make it use your instance instead of the production network. You can do this by passing the address as a parameter to a special MeshManager constructor that is available in the developer version of the library. Note that this will never be an option in production - all RightMesh applications will use the same network, so that the owner of the device can specify their preferences for where/when/how to connect to Superpeers.
+If you would like to have devices use your Superpeer instance for testing, you can hard-code its address into a RightMesh application to make it use your instance instead of the mainnet. You can do this by passing the address as a parameter to a special MeshManager constructor that is available in the developer version of the library. Note that this will never be an option on the mainnet - all RightMesh applications will use the same network, so that the owner of the device can specify their preferences for where/when/how to connect to Superpeers.
 
 If you would like to send data to a Java application that makes use of RightMesh in a production application, you will need to find out its MeshID and send data to it through the RightMesh library.
 
 ## Running the Superpeer as a Service
+
+This was all tested with the following:
+* Ubuntu 16.04.4 LTS
+* Java 8
+* Parity 1.8.6
+* RightMesh library 0.7.0
 
 This repo contains everything needed to set up a Superpeer as a service on Ubuntu. These steps will help you get started:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This minimalist RightMesh "Superpeer" implementation provides two functionalities: enabling the forwarding of data packets from one geographically separate mesh to another, and facilitating transactions involving RightMesh Tokens. The second functionality includes recording transactions to the Ethereum blockchain.
 
+## Running the Superpeer
+
+Superpeer is a Gradle application - it can be built with `gradlew build`, and a binary can be generated with `gradlew installDist`.
+
+If run without arguments Superpeer polls STDIN for input - typing `exit` will shut down RightMesh and stop the application. Unless you are developing/debugging, you will likely want to run Superpeer with the `-h | --headless` flag, which doesn't poll for input and responds to SIGINT signals (e.g. can be killed cleanly with `Ctrl+C` or task managers).
+
 ## Connecting to your Superpeer
 
 By default RightMesh devices with internet connections will connect to a Superpeer operated by RightMesh at `research.rightmesh.io`. In the future the goal is to have a network of Superpeers, with Superpeers implemented and operated by both RightMesh and community members.
@@ -10,7 +16,7 @@ If you would like to have devices use your Superpeer instance for testing, you c
 
 If you would like to send data to a Java application that makes use of RightMesh in a production application, you will need to find out its MeshID and send data to it through the RightMesh library.
 
-## Configuring a New Superpeer
+## Running the Superpeer as a Service
 
 This repo contains everything needed to set up a Superpeer as a service on Ubuntu. These steps will help you get started:
 

--- a/superpeer.service
+++ b/superpeer.service
@@ -1,5 +1,5 @@
 [Unit]
 Description=RightMesh Superpeer
 [Service]
-ExecStart=/home/ubuntu/Superpeer/build/install/Superpeer/bin/Superpeer --headless
+ExecStart=/home/ubuntu/superpeer/build/install/Superpeer/bin/Superpeer --headless
 User=ubuntu


### PR DESCRIPTION
This PR adds documentation on how to set up and run a Superpeer on an Ubuntu server. It also updates the path in `superpeer.service` to be consistent with those instructions.